### PR TITLE
php 8.0 compatibility

### DIFF
--- a/markdownSplit.php
+++ b/markdownSplit.php
@@ -50,7 +50,7 @@ class markdownSplit {
 			return $matches[0];
 		}
 		
-		$level = $matches[2]{0} == '=' ? '#' : '##';
+		$level = $matches[2][0] == '=' ? '#' : '##';
 		// ID attribute generation
 		return $block = $level. ' ' . $matches[1] . "\n\n";
 		// return "\n" . $this->hashBlock($block) . "\n\n";


### PR DESCRIPTION
This fixes the following error for php 8.0:

```
Fatal error: Array and string offset access syntax with curly braces is no longer supported in /vendor/diversen/markdown-split-by-header/markdownSplit.php on line 53
```